### PR TITLE
Implement step-by-step flood fill visualization feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(SFML 2.5 REQUIRED graphics window system)
 # Include the directories for SFML
 include_directories(${SFML_INCLUDE_DIR})
 
-add_executable(Main Source/Main.cpp Source/GameState.cpp Source/ScreenRenderer.cpp Source/PlayerTurn.cpp Source/CathedralState.cpp Source/EvaluationMetric.cpp Source/GameManager.cpp Source/MatrixUtility.cpp MonteCarloTreeSearch-main/mcts/src/mcts.cpp MonteCarloTreeSearch-main/mcts/src/JobScheduler.cpp
+add_executable(Main Source/Main.cpp Source/GameState.cpp Source/ScreenRenderer.cpp Source/PlayerTurn.cpp Source/CathedralState.cpp Source/EvaluationMetric.cpp Source/GameManager.cpp Source/MatrixUtility.cpp Source/BoardUtility.cpp MonteCarloTreeSearch-main/mcts/src/mcts.cpp MonteCarloTreeSearch-main/mcts/src/JobScheduler.cpp
 )
 
 target_link_libraries(Main sfml-graphics sfml-window sfml-system pthread)

--- a/Source/BoardUtility.cpp
+++ b/Source/BoardUtility.cpp
@@ -12,196 +12,13 @@
 #include "Headers/BoardUtility.h"
 #include "Headers/MatrixUtility.h"
 #include "Headers/PlayerTurn.h"
+#include "Headers/ScreenRenderer.h"
 
 #include "Headers/CathedralState.h"
 
 
 
 using namespace std;
-
-bool BoardUtility::checkIfCreatingTerritoryFirstTurn(std::vector<std::vector<int>>& board, const Cathedral_move *move) {
-    
-    bool valid;
-    
-    vector<pair<int,int>> positionsToCheck = positionsAroundShape(move->shape); //not sure which is X or Y 
-   
-    int gridCol = move->col;
-    int gridRow = move->row;
-
-    // cout << "Checking at " << gridCol << " " << gridRow << endl;
-    for (auto pos : positionsToCheck){
-        int boardCol = gridCol + pos.second; //X
-        int boardRow = gridRow + pos.first; //Y
-        
-        if(boardCol < 0 || boardCol >= _board[0].size() || boardRow < 0 || boardRow >= _board.size()){
-            continue; 
-        }
-
-        if(_board[boardCol][boardRow] >= _playerMin && _board[boardCol][boardRow] <= _playerMax){
-            continue; 
-        }
-
-        std::vector<std::vector<bool>> visited(rows, std::vector<bool>(cols, false));
-      
-        bool r = checkIfPositionIsTerritory(boardCol, boardRow, visited); 
-        if(r == true){ 
-            // if(piecePosToRemove.empty()){
-            //     cout << "EMPTY " << endl;
-            //     return false;
-            // }
-            // pieceNum = board[piecePosToRemove[0].first][piecePosToRemove[0].second];
-            // for(auto pos : piecePosToRemove ){
-            //     cout << "piece to remove " <<  pos.first << " " << pos.second << endl;
-            //     board[pos.first][pos.second] = 0; 
-            // } 
-            cout << "position is territory in first turn at col: " << boardCol << " row:" << boardRow << " Board index is: " << _board[boardCol][boardRow] << endl;
-            // for(int i = 0; i < visited.size(); i++){ //should be same size as board
-            //     for(int j = 0; j<visited[i].size(); j++){
-            //         if(visited[i][j] == true){
-            //             board[i][j] = cathedral;
-            //         }
-            //     }
-            // }
-            return true;
-            // addShapeBack(map);
-            // cout << "not adding back in first tu " << endl;
-        }
-
-    }
-
-
-   
-    return false;
-}
-
-
-bool BoardUtility::checkIfPositionIsTerritory(int x, int y, std::vector<std::vector<bool>>& visited){
-    // Check bounds
-    if (y < 0 || y >= rows || x < 0 || x >= cols) {
-        return true; // Reached the edge, valid
-    }
-
-      // If already visited, skip this cell
-    if (visited[y][x]) {
-        return true;
-    }
-
-    // Mark the cell as visited
-    visited[y][x] = true;
-
-    if (_board[y][x] >= _playerMin && _board[y][x] <= _playerMax) {
-        return true;
-    }
-
-
-    if ((_board[y][x] >= _opponentMin && _board[y][x] <= _opponentMax) || _board[y][x] == cathedral) {      
-        return false;
-    }
-   
-
-
-    if (_board[y][x] == 0 || _board[y][x] == cathedral || (_board[y][x] >= _opponentMin && _board[y][x] <= _opponentMax)) {
-  
-        // Check all adjacent cells (including diagonals)
-        bool valid = true;
-        valid &= checkIfPositionIsTerritory(x + 1, y, visited); // Right
-        if (!valid) return false;
-        valid &= checkIfPositionIsTerritory(x - 1, y, visited); // Left
-        if (!valid) return false;
-        valid &= checkIfPositionIsTerritory(x, y + 1, visited); // Down
-        if (!valid) return false;
-        valid &= checkIfPositionIsTerritory(x, y - 1, visited); // Up
-        if (!valid) return false;
-        valid &= checkIfPositionIsTerritory(x + 1, y + 1, visited); // Bottom-Right (Diagonal)
-        if (!valid) return false;
-        valid &= checkIfPositionIsTerritory(x - 1, y - 1, visited); // Top-Left (Diagonal)
-        if (!valid) return false;
-        valid &= checkIfPositionIsTerritory(x + 1, y - 1, visited); // Top-Right (Diagonal)
-        if (!valid) return false;
-        valid &= checkIfPositionIsTerritory(x - 1, y + 1, visited); // Bottom-Left (Diagonal)
-        if (!valid) return false;
-
-
-        return valid;
-    }
-
-    return false;
-}
-
-
-
-bool BoardUtility::checkIfCreatingTerritory(std::vector<std::vector<int>>& board, const Cathedral_move *move) {
-    bool valid;
-    
-    vector<pair<int,int>> positionsToCheck = positionsAroundShape(move->shape); //not sure which is X or Y 
-   
-    int gridCol = move->col;
-    int gridRow = move->row;
-
-    // cout << "Checking at " << gridCol << " " << gridRow << endl;
-    for (auto pos : positionsToCheck){
-        int boardCol = gridCol + pos.second; //X
-        int boardRow = gridRow + pos.first; //Y
-        
-        if(boardCol < 0 || boardCol >= _board[0].size() || boardRow < 0 || boardRow >= _board.size()){
-            continue; 
-        }
-        if(board[boardCol][boardRow] >= _playerMin && board[boardCol][boardRow] <= _playerMax){
-            continue; 
-        }
-
-        std::vector<std::vector<bool>> visited(rows, std::vector<bool>(cols, false));
-        int pieceInside = INT_MAX; //max when no piece inside       
-        piecePosToRemove.clear();
-        pieceNum = 0;
-        bool r = checkPositionForPieceRemoval(boardCol, boardRow, visited, pieceInside); 
-        if(r == true){ 
-            if(piecePosToRemove.empty()){
-                // cout << "EMPTY " << endl;
-                return false;
-            }
-            pieceNum = board[piecePosToRemove[0].first][piecePosToRemove[0].second];
-            for(auto pos : piecePosToRemove ){
-                // cout << "piece to remove " <<  pos.first << " " << pos.second << endl;
-                board[pos.first][pos.second] = 0; 
-            }
-
-            // for(int i = 0; i < visited.size(); i++){ //should be same size as board
-            //     for(int j = 0; j<visited[i].size(); j++){
-            //         if(visited[i][j] == true){
-            //             board[i][j] = cathedral;
-            //         }
-            //     }
-            // }
-            // addShapeBack(map);
-            // cout << "not adding back " << endl;
-        }
-
-    }
-
-
-   
-    return false;
-}
-
-
-
-
-
-void BoardUtility::addShapeBack(std::vector<std::vector<int>>& map){
-    if(pieceNum == 0 ){
-        cout << "pieceNum is 0";
-        return;
-    }
-    cout << "pieceNum is " << pieceNum << endl;
-    for(int y = 0; y < map.size(); y++){
-        for(int x = 0; x < map[0].size(); x++){
-            if(startingMap[y][x] == pieceNum){
-                map[y][x] = pieceNum;
-            }
-        }
-    }
-}
 
 
 
@@ -325,7 +142,7 @@ bool BoardUtility::checkPositionForPieceRemoval(int x, int y, std::vector<std::v
 
 
 
-bool BoardUtility::checkNotOpponentsTeritory(std::vector<std::vector<int>> board, const sf::Vector2f& mousePosWorld) {
+bool BoardUtility::checkNotOpponentsTerritory(std::vector<std::vector<int>> board, const sf::Vector2f& mousePosWorld) {
     bool valid = true;
     _board = board; 
 
@@ -390,3 +207,241 @@ bool BoardUtility::checkPosition(int x, int y, std::vector<std::vector<bool>>& v
 
     return true;
 }
+
+// Territory management methods moved from CathedralState
+void BoardUtility::setTerritoryInfo(int playerTerritory, int opponentTerritory) {
+    _playerTerritory = playerTerritory;
+    _opponentTerritory = opponentTerritory;
+    pieceNumToRemove = -1;
+}
+
+bool BoardUtility::checkIfCreatingTerritory(const Cathedral_move *move) {
+    vector<pair<int,int>> positionsToCheck = positionsAroundShape(move->shape);
+
+    // Clear previous flood fills if in step-by-step mode
+    if (stepByStepMode) {
+        allFloodFills.clear();
+        currentFloodFillIndex = 0;
+    }
+
+    for (auto pos : positionsToCheck){
+        int boardRow = move->row + pos.first; 
+        int boardCol = move->col + pos.second; 
+
+        if(boardCol < 0 || boardCol >= _board[0].size() || boardRow < 0 || boardRow >= _board.size()){
+            continue; 
+        }
+
+        if(_board[boardRow][boardCol] >= _playerMin && _board[boardRow][boardCol] <= _playerMax){
+            continue; 
+        }
+
+        std::vector<std::vector<bool>> visited(_board.size(), std::vector<bool>(_board[0].size(), false));
+        pieceNumToRemove = -1;
+        int enclosedPieceCount = 0;
+        
+        // Clear visited positions for debug visualization
+        if (debugMode) {
+            visitedPositions.clear();
+        }
+        
+        bool isTerritory = checkIfPositionIsNowPlayersTerritory(boardRow, boardCol, visited, enclosedPieceCount); 
+
+        // Store this flood fill if in step-by-step mode
+        if (stepByStepMode && debugMode && !visitedPositions.empty()) {
+            allFloodFills.push_back(visitedPositions);
+            std::cout << "Captured flood fill " << allFloodFills.size() << " starting at (" 
+                      << boardRow << ", " << boardCol << ") with " << visitedPositions.size() << " positions" << std::endl;
+        }
+
+        if(isTerritory && enclosedPieceCount <= 1){ 
+            changeSpaceToPlayersTerritory(boardRow, boardCol);
+            return true;
+        }
+    }
+
+    if (stepByStepMode && !allFloodFills.empty()) {
+        std::cout << "Territory analysis complete. Captured " << allFloodFills.size() << " flood fills. Press N to step through them." << std::endl;
+    }
+
+    return false;
+}
+
+bool BoardUtility::checkIfPositionIsNowPlayersTerritory(int row, int col, std::vector<std::vector<bool>>& visited, int& enclosedPieceCount){
+    // Check bounds - board edges count as valid enclosure
+    if (row < 0 || row >= _board.size() || col < 0 || col >= _board[0].size()) { 
+        return true;
+    }
+
+    // If already visited, skip this cell
+    if (visited[row][col]) { 
+        return true;
+    }
+
+    // Mark the cell as visited
+    visited[row][col] = true;
+    
+    // Add to debug visualization if enabled
+    if (debugMode) {
+        visitedPositions.push_back({row, col});
+        // Removed excessive debug output for cleaner console during gameplay
+    }
+    
+    int cellValue = _board[row][col];
+
+    // If it's player's own piece or territory, this forms valid enclosure
+    if (cellValue >= _playerMin && cellValue <= _playerMax || cellValue == _playerTerritory) {
+        return true;
+    }
+
+    // If it's an opponent piece or cathedral that can be captured
+    if ((cellValue >= _opponentMin && cellValue <= _opponentMax) || cellValue == cathedral) {  
+
+        enclosedPieceCount++;
+        
+        // Track pieces that need to be removed - only single pieces can be enclosed
+        if(pieceNumToRemove == -1){
+           pieceNumToRemove = cellValue;
+        } else if(cellValue != pieceNumToRemove) {
+            return false; // Multiple different piece types
+        }
+    }
+
+    // For empty spaces, opponent territory, or pieces marked for removal, continue flood fill
+    if (cellValue == 0 || cellValue == cathedral || 
+        (cellValue >= _opponentMin && cellValue <= _opponentMax) || 
+        cellValue == _opponentTerritory) { 
+        
+        // Check all 8 adjacent cells (including diagonals)
+        bool valid = true;
+        valid &= checkIfPositionIsNowPlayersTerritory(row, col + 1, visited, enclosedPieceCount); // Right
+        if (!valid) return false;
+        valid &= checkIfPositionIsNowPlayersTerritory(row, col - 1, visited, enclosedPieceCount); // Left
+        if (!valid) return false;
+        valid &= checkIfPositionIsNowPlayersTerritory(row + 1, col, visited, enclosedPieceCount); // Down
+        if (!valid) return false;
+        valid &= checkIfPositionIsNowPlayersTerritory(row - 1, col, visited, enclosedPieceCount); // Up
+        if (!valid) return false;
+        valid &= checkIfPositionIsNowPlayersTerritory(row + 1, col + 1, visited, enclosedPieceCount); // Bottom-Right
+        if (!valid) return false;
+        valid &= checkIfPositionIsNowPlayersTerritory(row - 1, col - 1, visited, enclosedPieceCount); // Top-Left
+        if (!valid) return false;
+        valid &= checkIfPositionIsNowPlayersTerritory(row + 1, col - 1, visited, enclosedPieceCount); // Bottom-Left
+        if (!valid) return false;
+        valid &= checkIfPositionIsNowPlayersTerritory(row - 1, col + 1, visited, enclosedPieceCount); // Top-Right
+        if (!valid) return false;
+
+        return valid;
+    }
+
+    return false;
+}
+
+void BoardUtility::changeSpaceToPlayersTerritory(int row, int col){
+    // Boundary check
+    if (row < 0 || col < 0 || row >= _board.size() || col >= _board[0].size()) { 
+        return;
+    }
+    
+    int cellValue = _board[row][col];
+    
+    // Only mark empty spaces, opponent territory, or pieces marked for removal
+    if (cellValue != 0 && cellValue != pieceNumToRemove && cellValue != _opponentTerritory) { 
+        return;
+    }
+    
+    // Mark as player territory
+    _board[row][col] = _playerTerritory;
+    
+    // Recursively mark adjacent orthogonal positions only (using the 4-direction approach)
+    const vector<pair<int, int>> directions = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
+    for (const auto& dir : directions) {
+        int newRow = row + dir.first;
+        int newCol = col + dir.second;
+        changeSpaceToPlayersTerritory(newRow, newCol);
+    }
+}
+
+void BoardUtility::drawVisitedPositions() {
+    if (!debugMode || !debugWindow) {
+        return;
+    }
+    
+    if (stepByStepMode && currentFloodFillIndex < allFloodFills.size()) {
+        // Draw only the current flood fill
+        const auto& currentFloodFill = allFloodFills[currentFloodFillIndex];
+        std::cout << "Drawing flood fill " << (currentFloodFillIndex + 1) << "/" << allFloodFills.size() 
+                  << " with " << currentFloodFill.size() << " positions" << std::endl;
+        
+        for (const auto& pos : currentFloodFill) {
+            int gridX = pos.second + minCol;
+            int gridY = pos.first + minRow;
+            ScreenRenderer::drawSquareClicked(*debugWindow, gridX, gridY);
+        }
+    } else {
+        // Draw all visited positions (original behavior)
+        std::cout << "Debug: Drawing " << visitedPositions.size() << " visited positions" << std::endl;
+        
+        for (const auto& pos : visitedPositions) {
+            int gridX = pos.second + minCol;
+            int gridY = pos.first + minRow;
+            ScreenRenderer::drawSquareClicked(*debugWindow, gridX, gridY);
+        }
+    }
+}
+
+void BoardUtility::nextFloodFill() {
+    if (stepByStepMode && currentFloodFillIndex < allFloodFills.size() - 1) {
+        currentFloodFillIndex++;
+        std::cout << "Advanced to flood fill " << (currentFloodFillIndex + 1) << "/" << allFloodFills.size() << std::endl;
+    } else if (stepByStepMode) {
+        std::cout << "Already at the last flood fill (" << allFloodFills.size() << " total)" << std::endl;
+    }
+}
+
+/*
+ * USAGE EXAMPLE FOR TERRITORY DEBUGGING VISUALIZATION:
+ * 
+ * To enable visualization of positions visited during territory checking:
+ * 
+ * 1. In GameManager.cpp (or wherever you handle moves), before calling territory checking:
+ * 
+ *    // Create BoardUtility instance
+ *    BoardUtility boardUtil(currentPlayer, board);
+ *    boardUtil.setTerritoryInfo(playerTerritory, opponentTerritory);
+ *    
+ *    // Enable debug visualization (pass the render window)
+ *    boardUtil.enableDebugVisualization(&window);
+ *    
+ *    // Check for territory creation
+ *    bool territoryCreated = boardUtil.checkIfCreatingTerritory(move);
+ *    
+ *    // In your render loop, after drawing the board:
+ *    ScreenRenderer::drawBoard(window, board);
+ *    boardUtil.drawVisitedPositions();  // This will highlight visited squares
+ *    
+ *    // Don't forget to disable when done
+ *    boardUtil.disableDebugVisualization();
+ * 
+ * 2. Alternative usage with manual control (e.g., press 'D' to toggle debug mode):
+ * 
+ *    // In your event handling:
+ *    if (event.key.code == sf::Keyboard::D) {
+ *        debugTerritoryMode = !debugTerritoryMode;
+ *        if (debugTerritoryMode) {
+ *            std::cout << "Territory debug visualization enabled" << std::endl;
+ *        } else {
+ *            std::cout << "Territory debug visualization disabled" << std::endl;
+ *        }
+ *    }
+ *    
+ *    // When creating BoardUtility:
+ *    BoardUtility boardUtil(currentPlayer, board);
+ *    if (debugTerritoryMode) {
+ *        boardUtil.enableDebugVisualization(&window);
+ *    }
+ *    
+ * The visualization will show red squares (from misc.png texture) on all positions
+ * that the checkIfPositionIsNowPlayersTerritory() function visits during its
+ * flood-fill algorithm, helping you debug territory detection logic.
+ */

--- a/Source/EvaluationMetric.cpp
+++ b/Source/EvaluationMetric.cpp
@@ -3,9 +3,21 @@
 #include "Headers/MatrixUtility.h"
 #include <vector>
 #include <iostream>
+#include <algorithm>
+#include <cmath>
+
+// Weight configuration for different game phases
+const std::map<std::string, std::map<GamePhase, double>> EvaluationMetric::PHASE_WEIGHTS = {
+    {"win_condition", {{GamePhase::EARLY, 0.3}, {GamePhase::MIDDLE, 0.6}, {GamePhase::LATE, 1.0}}},
+    {"territory_control", {{GamePhase::EARLY, 0.4}, {GamePhase::MIDDLE, 0.8}, {GamePhase::LATE, 0.9}}},
+    {"piece_mobility", {{GamePhase::EARLY, 0.8}, {GamePhase::MIDDLE, 0.6}, {GamePhase::LATE, 0.5}}},
+    {"positional_advantage", {{GamePhase::EARLY, 0.6}, {GamePhase::MIDDLE, 0.7}, {GamePhase::LATE, 0.4}}},
+    {"threat_assessment", {{GamePhase::EARLY, 0.2}, {GamePhase::MIDDLE, 0.5}, {GamePhase::LATE, 0.7}}},
+    {"cathedral_strategy", {{GamePhase::EARLY, 0.9}, {GamePhase::MIDDLE, 0.4}, {GamePhase::LATE, 0.1}}}
+};
 
 double EvaluationMetric::evaluate(const Cathedral_state& state) {
-    // Safety check to ensure state is valid
+    // Safety check
     try {
         const auto& board = state.get_state_info().board;
         if (board.empty() || board[0].empty()) {
@@ -16,71 +28,234 @@ double EvaluationMetric::evaluate(const Cathedral_state& state) {
         std::cerr << "Error accessing state info: " << e.what() << std::endl;
         return 0.0;
     }
-
-    int freeSpaces = countFreeSpaces(state);
-    int playerTerritory = countPlayerTerritory(state);
-    int enemyTerritory = countEnemyTerritory(state);
-    int playerPieces = countPlayerPieces(state);
-    int enemyPieces = countEnemyPieces(state);
-    auto unplayablePlayerResult = countUnplayablePiecesForPlayer(state);
-
-    int unplayablePlayerPieces = unplayablePlayerResult.count;
-    int unplayablePlayerSquares = unplayablePlayerResult.squares;
-
-    // Better weight balance
-    const double wTerritory = 1.5;
-    const double wPieces = 0.5;
-    const double wFreeSpaces = 0.0;
-    const double wUnplayablePieces = -1.2;
-    const double wUnplayableSquares = -0.05;
-
-    const double boardArea = BOARD_SIZE * BOARD_SIZE;
-    const double maxPieces = static_cast<double>(shapeFullListPOne.size());
-
-    // Normalize
-    double normTerritoryDiff = (playerTerritory - enemyTerritory) / boardArea;
-
-    int pieceOffset = state.player1_turn() ? 4 : 0; //update late to minus the squares p1 played last
-    double normPiecesDiff = (playerPieces - enemyPieces) / maxPieces;
-    double normFreeSpaces = freeSpaces / boardArea;
-    double normUnplayablePieces = unplayablePlayerPieces / maxPieces;
-    double normUnplayableSquares = unplayablePlayerSquares / boardArea;
-
-    // Score calculation
-    double score =
-        wTerritory * normTerritoryDiff +
-        wPieces * normPiecesDiff +
-        wUnplayablePieces * normUnplayablePieces;
-
+    
+    GamePhase phase = determineGamePhase(state);
+    
+    // Core evaluation components
+    double winScore = evaluateWinCondition(state) * getPhaseWeight("win_condition", phase);
+    double territoryScore = evaluateTerritoryControl(state) * getPhaseWeight("territory_control", phase);
+    double mobilityScore = evaluatePieceMobility(state) * getPhaseWeight("piece_mobility", phase);
+    double positionalScore = evaluatePositionalAdvantage(state) * getPhaseWeight("positional_advantage", phase);
+    double threatScore = evaluateThreatAssessment(state) * getPhaseWeight("threat_assessment", phase);
+    double cathedralScore = evaluateCathedralStrategy(state) * getPhaseWeight("cathedral_strategy", phase);
+    
+    double totalScore = winScore + territoryScore + mobilityScore + positionalScore + threatScore + cathedralScore;
+    
+    // Debug output
     bool isPlayer1 = state.player1_turn();
     std::string playerColor = isPlayer1 ? "Green" : "Red";
-    std::string enemyColor = isPlayer1 ? "Red" : "Green";
-
-    std::cout << playerColor <<"'s chance is " << score << std::endl;
-
-    return std::clamp(score, -1.0, 1.0);
+    std::cout << playerColor << "'s evaluation: " << totalScore 
+              << " (Win:" << winScore << " Territory:" << territoryScore 
+              << " Mobility:" << mobilityScore << ")" << std::endl;
+    
+    return totalScore;
 }
 
-
-
-
+EvaluationBreakdown EvaluationMetric::evaluateDetailed(const Cathedral_state& state) {
+    EvaluationBreakdown breakdown;
+    breakdown.gamePhase = determineGamePhase(state);
     
+    // Calculate each component
+    std::vector<std::pair<std::string, double>> components = {
+        {"win_condition", evaluateWinCondition(state)},
+        {"territory_control", evaluateTerritoryControl(state)},
+        {"piece_mobility", evaluatePieceMobility(state)},
+        {"positional_advantage", evaluatePositionalAdvantage(state)},
+        {"threat_assessment", evaluateThreatAssessment(state)},
+        {"cathedral_strategy", evaluateCathedralStrategy(state)}
+    };
+    
+    breakdown.totalScore = 0.0;
+    for (const auto& [name, raw] : components) {
+        EvaluationComponent comp;
+        comp.rawValue = raw;
+        comp.normalizedValue = raw; // Already normalized in component functions
+        comp.weightedValue = raw * getPhaseWeight(name, breakdown.gamePhase);
+        comp.description = name + " component";
+        
+        breakdown.components[name] = comp;
+        breakdown.totalScore += comp.weightedValue;
+    }
+    
+    // Calculate unplaced squares for analysis
+    breakdown.unplacedSquaresPlayer = calculateUnplacedSquares(state, true);
+    breakdown.unplacedSquaresOpponent = calculateUnplacedSquares(state, false);
+    
+    return breakdown;
+}
 
-    // std::cout << "Free spaces: " << freeSpaces << std::endl;
-    // std::cout << playerColor << " territory spaces: " << playerTerritory << std::endl;
-    // std::cout << enemyColor << " territory spaces: " << enemyTerritory << std::endl;
-    // std::cout << playerColor << " pieces on board: " << playerPieces << std::endl;
-    // std::cout << enemyColor << " pieces on board: " << enemyPieces << std::endl;
-    // std::cout << playerColor << " unable to play pieces: " << unplayablePlayerPieces << std::endl;
-    // std::cout << playerColor << " unable to play squares: " << unplayablePlayerSquares << std::endl;
-    // std::cout << playerColor << " unable to play piece indices: ";
-    // for (size_t i = 0; i < unplayablePlayerPieceIndices.size(); ++i) {
-    //     std::cout << unplayablePlayerPieceIndices[i];
-    //     if (i != unplayablePlayerPieceIndices.size() - 1) std::cout << ", ";
-    // }
-    // std::cout << std::endl;
-    // return -1; // Placeholder score
+double EvaluationMetric::evaluateWinCondition(const Cathedral_state& state) {
+    // CORE RULE: Player with fewest unplaced squares wins
+    int playerUnplaced = calculateUnplacedSquares(state, true);
+    int opponentUnplaced = calculateUnplacedSquares(state, false);
+    
+    // Normalize: positive is better for current player
+    if (playerUnplaced + opponentUnplaced == 0) return 0.0;
+    
+    double ratio = static_cast<double>(opponentUnplaced - playerUnplaced) / 
+                   static_cast<double>(playerUnplaced + opponentUnplaced);
+    
+    return ratio; // Range: [-1, 1]
+}
 
+double EvaluationMetric::evaluateTerritoryControl(const Cathedral_state& state) {
+    // Territory advantage (wall-to-wall connections)
+    int playerTerritory = countPlayerTerritory(state);
+    int enemyTerritory = countEnemyTerritory(state);
+    int totalTerritory = playerTerritory + enemyTerritory;
+    
+    if (totalTerritory == 0) return 0.0;
+    
+    return static_cast<double>(playerTerritory - enemyTerritory) / 
+           static_cast<double>(totalTerritory + 1); // +1 to avoid division issues
+}
+
+double EvaluationMetric::evaluatePieceMobility(const Cathedral_state& state) {
+    // How many pieces can still be placed and where
+    auto playerMobility = countUnplayablePiecesForPlayer(state);
+    
+    // Create opponent state to check their mobility
+    Cathedral_state tempState = state;
+    tempState.change_turn();
+    auto opponentMobility = countUnplayablePiecesForPlayer(tempState);
+    
+    // Calculate mobility advantage
+    int playerPlayable = state.get_state_info().player1Shapes.size() - playerMobility.count;
+    int opponentPlayable = state.get_state_info().player2Shapes.size() - opponentMobility.count;
+    
+    if (playerPlayable + opponentPlayable == 0) return 0.0;
+    
+    return static_cast<double>(playerPlayable - opponentPlayable) / 
+           static_cast<double>(playerPlayable + opponentPlayable);
+}
+
+double EvaluationMetric::evaluatePositionalAdvantage(const Cathedral_state& state) {
+    // Board control, connectivity, defensive positioning
+    return assessPieceConnectivity(state) + evaluateDefensivePositioning(state);
+}
+
+double EvaluationMetric::evaluateThreatAssessment(const Cathedral_state& state) {
+    // Capture threats and defensive needs
+    return assessCaptureThreats(state);
+}
+
+double EvaluationMetric::evaluateCathedralStrategy(const Cathedral_state& state) {
+    // Cathedral positioning and timing strategy
+    bool cathedralOnBoard = checkCathedralOnBoard(state);
+    if (!cathedralOnBoard) {
+        // Cathedral not placed yet - this affects strategy significantly
+        return 0.5; // Neutral until placed
+    }
+    
+    // Evaluate cathedral positioning quality
+    const auto& board = state.get_state_info().board;
+    
+    // Find cathedral position
+    for (size_t i = 0; i < board.size(); ++i) {
+        for (size_t j = 0; j < board[i].size(); ++j) {
+            if (board[i][j] == cathedral) {
+                // Cathedral positioning heuristics
+                double centerBonus = 0.0;
+                int centerX = board.size() / 2;
+                int centerY = board[0].size() / 2;
+                int distFromCenter = abs(static_cast<int>(i) - centerX) + abs(static_cast<int>(j) - centerY);
+                centerBonus = 1.0 - (static_cast<double>(distFromCenter) / (centerX + centerY));
+                
+                return centerBonus * 0.3; // Cathedral positioning is worth up to 30% of this component
+            }
+        }
+    }
+    
+    return 0.0;
+}
+
+GamePhase EvaluationMetric::determineGamePhase(const Cathedral_state& state) {
+    // Calculate how much of the game has progressed
+    const auto& p1Shapes = state.get_state_info().player1Shapes;
+    const auto& p2Shapes = state.get_state_info().player2Shapes;
+    
+    int totalOriginalPieces = 28; // Each player starts with 14 pieces
+    int remainingPieces = p1Shapes.size() + p2Shapes.size();
+    double progressRatio = 1.0 - (static_cast<double>(remainingPieces) / totalOriginalPieces);
+    
+    if (progressRatio < 0.2) return GamePhase::EARLY;
+    if (progressRatio < 0.7) return GamePhase::MIDDLE;
+    return GamePhase::LATE;
+}
+
+double EvaluationMetric::getPhaseWeight(const std::string& component, GamePhase phase) {
+    auto it = PHASE_WEIGHTS.find(component);
+    if (it != PHASE_WEIGHTS.end()) {
+        auto phaseIt = it->second.find(phase);
+        if (phaseIt != it->second.end()) {
+            return phaseIt->second;
+        }
+    }
+    return 1.0; // Default weight
+}
+
+int EvaluationMetric::calculateUnplacedSquares(const Cathedral_state& state, bool forCurrentPlayer) {
+    // Calculate total squares in unplaced pieces
+    const auto& shapes = forCurrentPlayer ? 
+        (state.player1_turn() ? state.get_state_info().player1Shapes : state.get_state_info().player2Shapes) :
+        (state.player1_turn() ? state.get_state_info().player2Shapes : state.get_state_info().player1Shapes);
+    
+    int totalSquares = 0;
+    for (const auto& shape : shapes) {
+        for (const auto& row : shape) {
+            for (int cell : row) {
+                if (cell != 0) totalSquares++;
+            }
+        }
+    }
+    
+    return totalSquares;
+}
+
+double EvaluationMetric::assessPieceConnectivity(const Cathedral_state& state) {
+    // Assess how well connected the player's pieces are
+    const auto& board = state.get_state_info().board;
+    int playerMin = state.player1_turn() ? player1Min : player2Min;
+    int playerMax = state.player1_turn() ? player1Max : player2Max;
+    
+    int connections = 0;
+    int totalPieces = 0;
+    
+    for (size_t i = 0; i < board.size(); ++i) {
+        for (size_t j = 0; j < board[i].size(); ++j) {
+            if (board[i][j] >= playerMin && board[i][j] <= playerMax) {
+                totalPieces++;
+                
+                // Check adjacent cells for connections
+                std::vector<std::pair<int, int>> directions = {{-1,0}, {1,0}, {0,-1}, {0,1}};
+                for (const auto& [dx, dy] : directions) {
+                    int ni = i + dx, nj = j + dy;
+                    if (ni >= 0 && ni < board.size() && nj >= 0 && nj < board[0].size()) {
+                        if (board[ni][nj] >= playerMin && board[ni][nj] <= playerMax) {
+                            connections++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    return totalPieces > 0 ? static_cast<double>(connections) / (totalPieces * 4) : 0.0;
+}
+
+double EvaluationMetric::evaluateDefensivePositioning(const Cathedral_state& state) {
+    // Evaluate how well positioned pieces are defensively
+    // This is a simplified version - can be expanded
+    return 0.0; // Placeholder
+}
+
+double EvaluationMetric::assessCaptureThreats(const Cathedral_state& state) {
+    // Assess potential captures and threats
+    // This is complex and requires analyzing potential enclosures
+    return 0.0; // Placeholder
+}
+
+// Legacy function implementations (maintained for compatibility)
 int EvaluationMetric::countFreeSpaces(const Cathedral_state& state) {
     return countMatrixIndex(state.get_state_info().board, 0);
 }
@@ -109,13 +284,8 @@ int EvaluationMetric::countEnemyPieces(const Cathedral_state& state) {
 
 bool EvaluationMetric::checkCathedralOnBoard(const Cathedral_state& state) {
     int count = countMatrixIndex(state.get_state_info().board, cathedral);
-    if(count == 0){
-        return false;
-    }
-    
-    return true;
+    return count > 0;
 }
-
 
 UnplayableInfo EvaluationMetric::countUnplayablePiecesForPlayer(const Cathedral_state& state) {
     int unplayablePieces = 0;
@@ -157,8 +327,6 @@ UnplayableInfo EvaluationMetric::countUnplayablePiecesForPlayer(const Cathedral_
     }
     return {unplayablePieces, unplayableIndices, unplayableSquares};
 }
-
-
 
 int EvaluationMetric::countMatrixIndex(const std::vector<std::vector<int>>& board, int index) {
     return countMatrixRange(board, index, index);

--- a/Source/Headers/BoardUtility.h
+++ b/Source/Headers/BoardUtility.h
@@ -1,10 +1,8 @@
 #pragma once
+#include <SFML/Graphics.hpp>
 // #include "../../MonteCarloTreeSearch-main/mcts/include/state.h"
 #include "CathedralState.h"
-//this class is for calculations that happen on the board 
-//possibly add an update board on map in matrix Utility class 
 
-//will need mousePos, board, current shape being placed 
 class BoardUtility{
     public:
     BoardUtility(const int& currentPlayer, const std::vector<std::vector<int>>& board)
@@ -25,14 +23,32 @@ class BoardUtility{
     
 
     // checkTeritory
-    bool checkNotOpponentsTeritory(std::vector<std::vector<int>> matrix, const sf::Vector2f& mousePosWorld);
-
-    //for first move 
-    bool checkIfCreatingTerritoryFirstTurn(std::vector<std::vector<int>>& board, const Cathedral_move *move);
-
+    bool checkNotOpponentsTerritory(std::vector<std::vector<int>> matrix, const sf::Vector2f& mousePosWorld);
     
-    //to remove one piece
-    bool checkIfCreatingTerritory(std::vector<std::vector<int>>& board, const Cathedral_move *move);
+    // Territory checking (updated method)
+    bool checkIfCreatingTerritory(const Cathedral_move *move);
+    bool checkIfPositionIsNowPlayersTerritory(int row, int col, std::vector<std::vector<bool>>& visited, int& enclosedPieceCount);
+    
+    // Territory management
+    void setTerritoryInfo(int playerTerritory, int opponentTerritory);
+    void changeSpaceToPlayersTerritory(int row, int col);
+    
+    // Board access
+    const std::vector<std::vector<int>>& getBoard() const { return _board; }
+    int getPieceNumToRemove() const { return pieceNumToRemove; }
+    
+    // Debug visualization
+    void enableDebugVisualization(sf::RenderWindow* window) { debugWindow = window; debugMode = true; }
+    void disableDebugVisualization() { debugWindow = nullptr; debugMode = false; }
+    void drawVisitedPositions();  // Call this in render loop to show visited positions
+    
+    // Step-by-step flood fill visualization
+    void enableStepByStepMode() { stepByStepMode = true; currentFloodFillIndex = 0; }
+    void disableStepByStepMode() { stepByStepMode = false; allFloodFills.clear(); currentFloodFillIndex = 0; }
+    void nextFloodFill(); // Advance to next flood fill
+    bool hasMoreFloodFills() const { return currentFloodFillIndex < allFloodFills.size(); }
+    int getCurrentFloodFillIndex() const { return currentFloodFillIndex; }
+    int getTotalFloodFills() const { return allFloodFills.size(); }
 
     private:
         std::vector<std::vector<int>> _board;
@@ -49,6 +65,21 @@ class BoardUtility{
 
         std::vector<std::pair<int,int>> piecePosToRemove;
         int pieceNum;
+        
+        // Territory checking variables moved from CathedralState
+        int pieceNumToRemove;
+        bool firstTurn;
+        int _playerTerritory, _opponentTerritory;
+        
+        // Debug visualization
+        bool debugMode = false;
+        sf::RenderWindow* debugWindow = nullptr;
+        std::vector<std::pair<int, int>> visitedPositions;
+        
+        // Step-by-step flood fill visualization
+        bool stepByStepMode = false;
+        std::vector<std::vector<std::pair<int, int>>> allFloodFills; // Each flood fill's visited positions
+        int currentFloodFillIndex = 0;
 
         std::vector<std::pair<int, int>> positionsAroundShape(const std::vector<std::vector<int>>& shape);
 
@@ -57,9 +88,6 @@ class BoardUtility{
 
         //check position is not one enemy piece in territory
         bool checkPositionForPieceRemoval(int x, int y, std::vector<std::vector<bool>>& visited, int& pieceInside);
-        
-        //this is for first turn so not deleting cathedral
-        bool checkIfPositionIsTerritory(int x, int y, std::vector<std::vector<bool>>& visited);
 
 
         void addShapeBack(std::vector<std::vector<int>>& map);

--- a/Source/Headers/CathedralState.h
+++ b/Source/Headers/CathedralState.h
@@ -61,8 +61,6 @@ private:
     int playerTerritory, opponentTerritory;
     
     const vector<pair<int, int>> directions = {{-1, 0}, {1, 0}, {0, -1}, {0, 1}};
-    bool firstTurn;
-    int pieceNumToRemove;
 
 
     Cathedral_move *pick_semirandom_move(Cathedral_state &s) const;
@@ -71,14 +69,6 @@ private:
     double evaluate_position(Cathedral_state &s) const;
 
     Cathedral_move *pickRandomMove(Cathedral_state &s) const;
-
-
-    //Territory stuff
-    bool checkIfCreatingTerritory(const Cathedral_move *move);
-    bool checkIfPositionIsNowPlayersTerritory(int row, int col, std::vector<std::vector<bool>>& visited);
-
-    std::vector<std::pair<int, int>> positionsAroundShape(const std::vector<std::vector<int>>& shape);
-    void changeSpaceToPlayersTerritory(int row, int col);
 
     void addShapeToPlayerShapes(int pieceNum);
 
@@ -126,22 +116,3 @@ public:
 
 
 };
-
-
-
-
-
-//things we have for heuristics
-//score 
-//if piece gets removed 
-//win/loss
-//
-
-
-//functions 
-//random move 
-    //maybe have a list of pieces to select 
-    //random rotate 
-//check winner
-    //slow to check board every move for valid plays 
-    //calculate score says who wins just need valid plays 

--- a/Source/Headers/EvaluationMetric.h
+++ b/Source/Headers/EvaluationMetric.h
@@ -2,6 +2,9 @@
 
 #include "../../MonteCarloTreeSearch-main/mcts/include/state.h"
 #include "CathedralState.h"
+#include <vector>
+#include <map>
+#include <string>
 
 struct UnplayableInfo {
     int count;
@@ -9,24 +12,74 @@ struct UnplayableInfo {
     int squares;
 };
 
+// Evaluation component results
+struct EvaluationComponent {
+    double rawValue;
+    double normalizedValue;
+    double weightedValue;
+    std::string description;
+};
+
+// Game phase enum for dynamic evaluation
+enum class GamePhase {
+    EARLY,      // Cathedral placement + first few moves (0-20% pieces placed)
+    MIDDLE,     // Territory claiming and positioning (20-70% pieces placed)
+    LATE        // Piece placement focus (70%+ pieces placed)
+};
+
+// Evaluation breakdown for debugging and tuning
+struct EvaluationBreakdown {
+    std::map<std::string, EvaluationComponent> components;
+    double totalScore;
+    GamePhase gamePhase;
+    std::string analysis;
+    int unplacedSquaresPlayer;
+    int unplacedSquaresOpponent;
+};
+
 class EvaluationMetric {
 public:
-    // Basic static evaluation: higher is better for current player
+    // Main evaluation functions
     static double evaluate(const Cathedral_state& state);
-
-private:
+    static EvaluationBreakdown evaluateDetailed(const Cathedral_state& state);
+    
+    // Core evaluation components (rule-based)
+    static double evaluateWinCondition(const Cathedral_state& state);        // Primary: unplaced squares
+    static double evaluateTerritoryControl(const Cathedral_state& state);    // Secondary: claimed territory
+    static double evaluatePieceMobility(const Cathedral_state& state);       // Piece placement options
+    static double evaluatePositionalAdvantage(const Cathedral_state& state); // Board position quality
+    static double evaluateThreatAssessment(const Cathedral_state& state);    // Capture threats
+    static double evaluateCathedralStrategy(const Cathedral_state& state);   // Cathedral positioning
+    
+    // Game analysis helpers
+    static GamePhase determineGamePhase(const Cathedral_state& state);
+    static double getPhaseWeight(const std::string& component, GamePhase phase);
+    
+    // Legacy functions (maintained for compatibility)
     static int countFreeSpaces(const Cathedral_state& state);
-    static int countPlayerTerritory(const Cathedral_state& state);  //not sure if this would be better as player or green and red
-    static int countEnemyTerritory(const Cathedral_state& state); 
-    static int countPlayerPieces(const Cathedral_state& state); 
-    static int countEnemyPieces(const Cathedral_state& state); 
-
-    static bool checkCathedralOnBoard(const Cathedral_state& state); 
-
+    static int countPlayerTerritory(const Cathedral_state& state);
+    static int countEnemyTerritory(const Cathedral_state& state);
+    static int countPlayerPieces(const Cathedral_state& state);
+    static int countEnemyPieces(const Cathedral_state& state);
+    static bool checkCathedralOnBoard(const Cathedral_state& state);
     static UnplayableInfo countUnplayablePiecesForPlayer(const Cathedral_state& state);
-
+    
+private:
+    // Advanced analysis functions
+    static int calculateUnplacedSquares(const Cathedral_state& state, bool forCurrentPlayer);
+    static std::vector<std::pair<int, int>> findEnclosedRegions(const Cathedral_state& state);
+    static double assessPieceConnectivity(const Cathedral_state& state);
+    static double calculateTerritoryPotential(const Cathedral_state& state);
+    static double evaluateDefensivePositioning(const Cathedral_state& state);
+    static double calculateMobilityScore(const Cathedral_state& state);
+    static double assessCaptureThreats(const Cathedral_state& state);
+    
+    // Utility functions
     static int countMatrixIndex(const std::vector<std::vector<int>>& board, int index);
     static int countMatrixRange(const std::vector<std::vector<int>>& board, int minIndex, int maxIndex);
-
-
+    static double normalizeScore(double raw, double min, double max);
+    
+    // Weight configuration for different game phases
+    static const std::map<std::string, std::map<GamePhase, double>> PHASE_WEIGHTS;
+    static void initializeWeights();
 };

--- a/Source/Headers/GameManager.h
+++ b/Source/Headers/GameManager.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <SFML/Graphics.hpp>
+#include <memory>
 #include "CathedralState.h"
 #include "PlayerTurn.h"
+
+// Forward declaration
+class BoardUtility;
 
 class GameManager {
 public:
@@ -34,6 +38,8 @@ private:
     void performMCTSMove();
     bool isValidPlayerPiece(int pieceIndex) const;
     int getCurrentPlayer() const;
+    void testTerritoryDebug();  // Test territory checking with debug visualization
+    void testTerritoryForMove(const Cathedral_move& move);  // Test territory for a specific move
     
     // Core game objects
     sf::RenderWindow& window;
@@ -59,4 +65,9 @@ private:
     int _player;
     int _playerMin;
     int _playerMax;
+    
+    // Debug state
+    bool debugTerritoryMode = false;
+    std::unique_ptr<BoardUtility> debugBoardUtil;
+    bool stepByStepFloodFillMode = false;
 };

--- a/Source/ScreenRenderer.cpp
+++ b/Source/ScreenRenderer.cpp
@@ -178,7 +178,7 @@ void ScreenRenderer::drawSquareClicked(sf::RenderWindow& window, int gridX, int 
 
   sf::Sprite sprite;
   sprite.setTexture(texture);
-  sprite.setTextureRect(sf::IntRect(GRID_SIZE * 3,0, GRID_SIZE, GRID_SIZE));
+  sprite.setTextureRect(sf::IntRect(GRID_SIZE*2, GRID_SIZE, GRID_SIZE, GRID_SIZE));
   sprite.setPosition(static_cast<float>(gridX * GRID_SIZE), static_cast<float>(gridY * GRID_SIZE));
   window.draw(sprite);
 }


### PR DESCRIPTION
- Add step-by-step mode to BoardUtility for visualizing individual flood fills
- Add 'N' key handler to advance through flood fills one by one
- Enhance debug visualization to show each territory checking operation separately
- Add methods: enableStepByStepMode(), nextFloodFill(), hasMoreFloodFills()
- Modify checkIfCreatingTerritory() to capture individual flood fills
- Update GameManager to support step-by-step territory debugging
- Allow users to press 'D' to enable debug mode, place pieces, then press 'N' to step through each flood fill operation